### PR TITLE
Fix bug no datas sur l'onglet Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ This is a generic Teleinfo French Meter Measure Library
 - Github source : <https://github.com/hallard/LibTeleinfo>
 
 # Added features :
-- Add all possible variable (without ejp) following : 
+- Add possibility to configure HttpRequest to send parameters/values to Domoticz
+- Add all possible variable as listed below : 
+- Add some informations to 'System' page, like Wifi link quality, Wifi network name, and MAC address
 
 Ces différents messages donnent les indications suivantes en fonction de l’abonnement souscrit :
 - N° d’identification du compteur : ADCO (12 caractères)
@@ -31,5 +33,4 @@ Ces différents messages donnent les indications suivantes en fonction de l’ab
 - Groupe horaire si option = heures creuses ou tempo : HHPHC (1 car.)
 - Mot d’état (autocontrôle) : MOTDETAT (6 car.)
 
-HTTP Request push datas 
 

--- a/README.md
+++ b/README.md
@@ -3,33 +3,33 @@ This is a fork of Teleinfo Universal Library for the ESP8266 MCU
 This is a generic Teleinfo French Meter Measure Library  
 - Github source : <https://github.com/hallard/LibTeleinfo>
 
-# My Features
+# Added features :
 - Add all possible variable (without ejp) following : 
 
 Ces différents messages donnent les indications suivantes en fonction de l’abonnement souscrit :
-N° d’identification du compteur : ADCO (12 caractères)
-Option tarifaire (type d’abonnement) : OPTARIF (4 car.)
-Intensité souscrite : ISOUSC ( 2 car. unité = ampères)
-Index si option = base : BASE ( 9 car. unité = Wh)
-Index heures creuses si option = heures creuses : HCHC ( 9 car. unité = Wh)
-Index heures pleines si option = heures creuses : HCHP ( 9 car. unité = Wh)
-Index heures normales si option = EJP : EJP HN ( 9 car. unité = Wh)
-Index heures de pointe mobile si option = EJP : EJP HPM ( 9 car. unité = Wh)
-Index heures creuses jours bleus si option = tempo : BBR HC JB ( 9 car. unité = Wh)
-Index heures pleines jours bleus si option = tempo : BBR HP JB ( 9 car. unité = Wh)
-Index heures creuses jours blancs si option = tempo : BBR HC JW ( 9 car. unité = Wh)
-Index heures pleines jours blancs si option = tempo : BBR HP JW ( 9 car. unité = Wh)
-Index heures creuses jours rouges si option = tempo : BBR HC JR ( 9 car. unité = Wh)
-Index heures pleines jours rouges si option = tempo : BBR HP JR ( 9 car. unité = Wh)
-Préavis EJP si option = EJP : PEJP ( 2 car.) 30mn avant période EJP
-Période tarifaire en cours : PTEC ( 4 car.)
-Couleur du lendemain si option = tempo : DEMAIN
-Intensité instantanée : IINST ( 3 car. unité = ampères)
-Avertissement de dépassement de puissance souscrite : ADPS ( 3 car. unité = ampères) (message émis uniquement en cas de dépassement effectif, dans ce cas il est immédiat)
-Intensité maximale : IMAX ( 3 car. unité = ampères)
-Puissance apparente : PAPP ( 5 car. unité = Volt.ampères)
-Groupe horaire si option = heures creuses ou tempo : HHPHC (1 car.)
-Mot d’état (autocontrôle) : MOTDETAT (6 car.)
+- N° d’identification du compteur : ADCO (12 caractères)
+- Option tarifaire (type d’abonnement) : OPTARIF (4 car.)
+- Intensité souscrite : ISOUSC ( 2 car. unité = ampères)
+- Index si option = base : BASE ( 9 car. unité = Wh)
+- Index heures creuses si option = heures creuses : HCHC ( 9 car. unité = Wh)
+- Index heures pleines si option = heures creuses : HCHP ( 9 car. unité = Wh)
+- Index heures normales si option = EJP : EJP HN ( 9 car. unité = Wh)
+- Index heures de pointe mobile si option = EJP : EJP HPM ( 9 car. unité = Wh)
+- Index heures creuses jours bleus si option = tempo : BBR HC JB ( 9 car. unité = Wh)
+- Index heures pleines jours bleus si option = tempo : BBR HP JB ( 9 car. unité = Wh)
+- Index heures creuses jours blancs si option = tempo : BBR HC JW ( 9 car. unité = Wh)
+- Index heures pleines jours blancs si option = tempo : BBR HP JW ( 9 car. unité = Wh)
+- Index heures creuses jours rouges si option = tempo : BBR HC JR ( 9 car. unité = Wh)
+- Index heures pleines jours rouges si option = tempo : BBR HP JR ( 9 car. unité = Wh)
+- Préavis EJP si option = EJP : PEJP ( 2 car.) 30mn avant période EJP
+- Période tarifaire en cours : PTEC ( 4 car.)
+- Couleur du lendemain si option = tempo : DEMAIN
+- Intensité instantanée : IINST ( 3 car. unité = ampères)
+- Avertissement de dépassement de puissance souscrite : ADPS ( 3 car. unité = ampères) (message émis uniquement en cas de dépassement effectif, dans ce cas il est immédiat)
+- Intensité maximale : IMAX ( 3 car. unité = ampères)
+- Puissance apparente : PAPP ( 5 car. unité = Volt.ampères)
+- Groupe horaire si option = heures creuses ou tempo : HHPHC (1 car.)
+- Mot d’état (autocontrôle) : MOTDETAT (6 car.)
 
 HTTP Request push datas 
 

--- a/examples/Wifinfo/Wifinfo.h
+++ b/examples/Wifinfo/Wifinfo.h
@@ -50,7 +50,7 @@ extern "C" {
 #define DEBUG_SERIAL	Serial1
 #define DEBUG_SERIAL1	
 
-#define WIFINFO_VERSION "1.0.1"
+#define WIFINFO_VERSION "1.0.2"
 
 // I prefix debug macro to be sure to use specific for THIS library
 // debugging, this should not interfere with main sketch or other 

--- a/examples/Wifinfo/Wifinfo.h
+++ b/examples/Wifinfo/Wifinfo.h
@@ -50,7 +50,7 @@ extern "C" {
 #define DEBUG_SERIAL	Serial1
 #define DEBUG_SERIAL1	
 
-#define WIFINFO_VERSION "1.0.2"
+#define WIFINFO_VERSION "1.0.3"
 
 // I prefix debug macro to be sure to use specific for THIS library
 // debugging, this should not interfere with main sketch or other 

--- a/examples/Wifinfo/Wifinfo.h
+++ b/examples/Wifinfo/Wifinfo.h
@@ -50,7 +50,7 @@ extern "C" {
 #define DEBUG_SERIAL	Serial1
 #define DEBUG_SERIAL1	
 
-#define WIFINFO_VERSION "1.0.3"
+#define WIFINFO_VERSION "1.0.2"
 
 // I prefix debug macro to be sure to use specific for THIS library
 // debugging, this should not interfere with main sketch or other 

--- a/examples/Wifinfo/Wifinfo.ino
+++ b/examples/Wifinfo/Wifinfo.ino
@@ -89,8 +89,9 @@ void UpdateSysinfo(boolean first_call, boolean show_debug)
   int sec = seconds;
   int min = sec / 60;
   int hr = min / 60;
+  long day = hr / 24;
 
-  sprintf_P( buff, PSTR("%02d:%02d:%02d"), hr, min % 60, sec % 60);
+  sprintf_P( buff, PSTR("%ld days %02d h %02d m %02d sec"),day, hr % 24, min % 60, sec % 60);
   sysinfo.sys_uptime = buff;
 }
 

--- a/examples/Wifinfo/Wifinfo.ino
+++ b/examples/Wifinfo/Wifinfo.ino
@@ -34,6 +34,7 @@
 #include <NeoPixelBus.h>
 #include <LibTeleinfo.h>
 #include <FS.h>
+#include <SPI.h>
 
 // Global project file
 #include "Wifinfo.h"

--- a/examples/Wifinfo/Wifinfo.ino
+++ b/examples/Wifinfo/Wifinfo.ino
@@ -75,6 +75,9 @@ unsigned long seconds = 0;
 // sysinfo data
 _sysinfo sysinfo;
 
+// count Wifi connect attempts, to check stability
+int       nb_reconnect = 0;
+
 /* ======================================================================
 Function: UpdateSysinfo 
 Purpose : update sysinfo variables
@@ -479,6 +482,7 @@ int WifiHandleConn(boolean setup = false)
     // connected ? disable AP, client mode only
     if (ret == WL_CONNECTED)
     {
+      nb_reconnect++;         // increase reconnections count
       DebuglnF("connected!");
       WiFi.mode(WIFI_STA);
 

--- a/examples/Wifinfo/webserver.cpp
+++ b/examples/Wifinfo/webserver.cpp
@@ -417,7 +417,10 @@ void getSysJSONData(String & response)
       response += macaddress;
       response += "\"},\r\n";
   }
-    
+  response += "{\"na\":\"Nb reconnexions Wifi\",\"va\":\"";
+  response += nb_reconnect;
+  response += "\"},\r\n"; 
+  
   response += "{\"na\":\"WifInfo Version\",\"va\":\"" WIFINFO_VERSION "\"},\r\n";
 
   response += "{\"na\":\"Compile le\",\"va\":\"" __DATE__ " " __TIME__ "\"},\r\n";

--- a/examples/Wifinfo/webserver.cpp
+++ b/examples/Wifinfo/webserver.cpp
@@ -406,6 +406,16 @@ void getSysJSONData(String & response)
       response += "{\"na\":\"Wifi RSSI\",\"va\":\"";
       response += WiFi.RSSI();
       response += " dB\"},\r\n";
+      response += "{\"na\":\"Wifi network\",\"va\":\"";
+      response += config.ssid;
+      response += "\"},\r\n";
+      uint8_t mac[] = {0, 0, 0, 0, 0, 0};
+      uint8_t* macread = WiFi.macAddress(mac);
+      char macaddress[20];
+      sprintf_P(macaddress, PSTR("%02x:%02x:%02x:%02x:%02x:%02x"), macread[0], macread[1], macread[2], macread[3], macread[4], macread[5]);
+      response += "{\"na\":\"Adresse MAC station\",\"va\":\"";
+      response += macaddress;
+      response += "\"},\r\n";
   }
     
   response += "{\"na\":\"WifInfo Version\",\"va\":\"" WIFINFO_VERSION "\"},\r\n";

--- a/examples/Wifinfo/webserver.cpp
+++ b/examples/Wifinfo/webserver.cpp
@@ -401,6 +401,13 @@ void getSysJSONData(String & response)
   response += sysinfo.sys_uptime;
   response += "\"},\r\n";
 
+  if (WiFi.status() == WL_CONNECTED)
+  {
+      response += "{\"na\":\"Wifi RSSI\",\"va\":\"";
+      response += WiFi.RSSI();
+      response += " dB\"},\r\n";
+  }
+    
   response += "{\"na\":\"WifInfo Version\",\"va\":\"" WIFINFO_VERSION "\"},\r\n";
 
   response += "{\"na\":\"Compile le\",\"va\":\"" __DATE__ " " __TIME__ "\"},\r\n";

--- a/examples/Wifinfo/webserver.cpp
+++ b/examples/Wifinfo/webserver.cpp
@@ -521,7 +521,7 @@ void getConfJSONData(String & r)
   r+=CFG_FORM_JDOM_URL;  r+=FPSTR(FP_QCQ); r+=config.jeedom.url;    r+= FPSTR(FP_QCNL); 
   r+=CFG_FORM_JDOM_KEY;  r+=FPSTR(FP_QCQ); r+=config.jeedom.apikey; r+= FPSTR(FP_QCNL); 
   r+=CFG_FORM_JDOM_ADCO; r+=FPSTR(FP_QCQ); r+=config.jeedom.adco;   r+= FPSTR(FP_QCNL); 
-  r+=CFG_FORM_JDOM_FREQ; r+=FPSTR(FP_QCQ); r+=config.jeedom.freq;  
+  r+=CFG_FORM_JDOM_FREQ; r+=FPSTR(FP_QCQ); r+=config.jeedom.freq;   r+= FPSTR(FP_QCNL); 
 
   r+=CFG_FORM_HTTPREQ_HOST; r+=FPSTR(FP_QCQ); r+=config.httpReq.host;   r+= FPSTR(FP_QCNL); 
   r+=CFG_FORM_HTTPREQ_PORT; r+=FPSTR(FP_QCQ); r+=config.httpReq.port;   r+= FPSTR(FP_QCNL); 

--- a/examples/Wifinfo/webserver.h
+++ b/examples/Wifinfo/webserver.h
@@ -33,6 +33,7 @@
 // ===================================================
 extern char response[];
 extern uint16_t response_idx;
+extern int      nb_reconnect;
 
 // declared exported function from route.cpp
 // ===================================================


### PR DESCRIPTION
La Json table de configuration était mal formée.
Manquait un séparateur de ligne juste avant bloc HttpRequest

Cosmétique sur onglet 'Système' : ajout qualité lien Wifi, nom du réseau Wifi, et MAC Address de la station

Passage Wifinfo en version 1.0.2
